### PR TITLE
Update HttpPolicyExtensions.cs

### DIFF
--- a/src/Polly.Extensions.Http/HttpPolicyExtensions.cs
+++ b/src/Polly.Extensions.Http/HttpPolicyExtensions.cs
@@ -11,7 +11,7 @@ namespace Polly.Extensions.Http
     {
         private static readonly Func<HttpResponseMessage, bool> TransientHttpStatusCodePredicate = (response) =>
         {
-            return (int)response.StatusCode >= 500 || response.StatusCode == HttpStatusCode.RequestTimeout;
+            return (int)response.StatusCode > 500 || response.StatusCode == HttpStatusCode.RequestTimeout;
         };
 
         /// <summary>


### PR DESCRIPTION
the current 5XX check includes 500 which is not TransientError, which requires code changes or query changes by the dev team.

1. so retry for 500  always returns 500
2. if there is dependency on 1 Service for 2 different Api calls and 2 different workflows, opening circuit makes the entire Service unavailable.