### PR TITLE
consider WebException transient

### DIFF
--- a/src/Polly.Extensions.Http/HttpPolicyExtensions.cs
+++ b/src/Polly.Extensions.Http/HttpPolicyExtensions.cs
@@ -27,7 +27,10 @@ namespace Polly.Extensions.Http
         /// <returns>The <see cref="PolicyBuilder{HttpResponseMessage}"/> pre-configured to handle <see cref="HttpClient"/> requests that fail with conditions indicating a transient failure. </returns>
         public static PolicyBuilder<HttpResponseMessage> HandleTransientHttpError()
         {
-            return Policy<HttpResponseMessage>.Handle<HttpRequestException>().OrTransientHttpStatusCode();
+            return Policy<HttpResponseMessage>
+                .Handle<HttpRequestException>()
+                .Or<WebException>()
+                .OrTransientHttpStatusCode();
         }
 
         /// <summary>


### PR DESCRIPTION
On `net6.0-android`, A lot of the errors come through `WebException` instead of `HttpResponseMessage`.

Is this a change folks are willing to take in? I realize the PR needs tests.

![image](https://user-images.githubusercontent.com/1633368/175824866-c4f08b84-2d1f-4756-b140-314921634431.png)


![image](https://user-images.githubusercontent.com/1633368/175824880-1a1bfb15-ac3f-44f1-ba8f-6ec2f94e1848.png)
